### PR TITLE
Replaced System.Drawing.Common with SixLabors.ImageSharp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vs/
 bin/
 obj/
+
+*.psd

--- a/bzPSD.Sample/Program.cs
+++ b/bzPSD.Sample/Program.cs
@@ -1,0 +1,25 @@
+﻿using bzPSD;
+using System.Diagnostics;
+using SixLabors.ImageSharp;
+
+var filePath = args.FirstOrDefault() ?? "Sample.psd";
+filePath = Path.GetFullPath(filePath);
+Console.WriteLine(filePath);
+
+var resultFile = "Sample.png";
+resultFile = Path.GetFullPath(resultFile);
+Console.WriteLine(resultFile);
+
+var psd = new PsdFile().Load(filePath);
+using var image = ImageDecoder.DecodeImage(psd);
+using var output = File.Create(resultFile);
+image.SaveAsPng(output);
+
+var process = new Process
+{
+    StartInfo = new ProcessStartInfo(resultFile)
+    {
+        UseShellExecute = true
+    }
+};
+process.Start();

--- a/bzPSD.Sample/bzPSD.Sample.csproj
+++ b/bzPSD.Sample/bzPSD.Sample.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\bzPSD\bzPSD.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Sample.psd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/bzPSD.sln
+++ b/bzPSD.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bzPSD.Sample", "bzPSD.Sample\bzPSD.Sample.csproj", "{62691E03-1E53-42D9-B107-822E65A9BAA0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{9906A61E-E46C-4A25-B54C-599AB0A0595B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9906A61E-E46C-4A25-B54C-599AB0A0595B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9906A61E-E46C-4A25-B54C-599AB0A0595B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62691E03-1E53-42D9-B107-822E65A9BAA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62691E03-1E53-42D9-B107-822E65A9BAA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62691E03-1E53-42D9-B107-822E65A9BAA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62691E03-1E53-42D9-B107-822E65A9BAA0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/bzPSD/ImageDecoder.cs
+++ b/bzPSD/ImageDecoder.cs
@@ -113,7 +113,7 @@ namespace bzPSD
                 {
                     int pos = rowIndex + x;
 
-                    Color pixelColor = Color.FromArgb(mask.ImageData[pos], mask.ImageData[pos], mask.ImageData[pos]);
+                    Color pixelColor = Color.FromRgb(mask.ImageData[pos], mask.ImageData[pos], mask.ImageData[pos]);
 
                     lock (bitmap)
                     {
@@ -156,7 +156,7 @@ namespace bzPSD
                     break;
                 case ColorMode.Indexed:
                     int index = red;
-                    c = Color.FromArgb(psdFile.ColorModeData[index], psdFile.ColorModeData[index + 256], psdFile.ColorModeData[index + 2 * 256]);
+                    c = Color.FromRgb(psdFile.ColorModeData[index], psdFile.ColorModeData[index + 256], psdFile.ColorModeData[index + 2 * 256]);
                     break;
                 case ColorMode.Lab:
                     c = LabToRGB(red, green, blue);
@@ -173,7 +173,7 @@ namespace bzPSD
             switch (layer.PsdFile.ColorMode)
             {
                 case ColorMode.RGB:
-                    c = Color.FromArgb(layer.SortedChannels[0].ImageData[pos], layer.SortedChannels[1].ImageData[pos], layer.SortedChannels[2].ImageData[pos]);
+                    c = Color.FromRgb(layer.SortedChannels[0].ImageData[pos], layer.SortedChannels[1].ImageData[pos], layer.SortedChannels[2].ImageData[pos]);
                     break;
                 case ColorMode.CMYK:
                     c = CMYKToRGB(layer.SortedChannels[0].ImageData[pos], layer.SortedChannels[1].ImageData[pos], layer.SortedChannels[2].ImageData[pos], layer.SortedChannels[3].ImageData[pos]);
@@ -183,12 +183,12 @@ namespace bzPSD
                     break;
                 case ColorMode.Grayscale:
                 case ColorMode.Duotone:
-                    c = Color.FromArgb(layer.SortedChannels[0].ImageData[pos], layer.SortedChannels[0].ImageData[pos], layer.SortedChannels[0].ImageData[pos]);
+                    c = Color.FromRgb(layer.SortedChannels[0].ImageData[pos], layer.SortedChannels[0].ImageData[pos], layer.SortedChannels[0].ImageData[pos]);
                     break;
                 case ColorMode.Indexed:
                     {
                         int index = layer.SortedChannels[0].ImageData[pos];
-                        c = Color.FromArgb(layer.PsdFile.ColorModeData[index], layer.PsdFile.ColorModeData[index + 256], layer.PsdFile.ColorModeData[index + 2 * 256]);
+                        c = Color.FromRgb(layer.PsdFile.ColorModeData[index], layer.PsdFile.ColorModeData[index + 256], layer.PsdFile.ColorModeData[index + 2 * 256]);
                     }
                     break;
                 case ColorMode.Lab:
@@ -293,7 +293,7 @@ namespace bzPSD
             nBlue = nBlue > 0 ? nBlue : 0;
             nBlue = nBlue < 255 ? nBlue : 255;
 
-            return Color.FromArgb(nRed, nGreen, nBlue);
+            return Color.FromRgb((byte)nRed, (byte)nGreen, (byte)nBlue);
         }
 
         ///////////////////////////////////////////////////////////////////////////////
@@ -336,7 +336,7 @@ namespace bzPSD
             nBlue = nBlue > 0 ? nBlue : 0;
             nBlue = nBlue < 255 ? nBlue : 255;
 
-            return Color.FromArgb(nRed, nGreen, nBlue);
+            return Color.FromRgb((byte)nRed, (byte)nGreen, (byte)nBlue);
         }
     }
 }

--- a/bzPSD/ImageDecoder.cs
+++ b/bzPSD/ImageDecoder.cs
@@ -27,10 +27,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 using System;
-using System.Drawing;
-using System.Drawing.Imaging;
+using SixLabors.ImageSharp;
 using System.Drawing.PSD;
+using System.Numerics;
 using System.Threading.Tasks;
+using Bitmap = SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Argb32>;
 
 namespace bzPSD
 {
@@ -38,7 +39,7 @@ namespace bzPSD
     {
         public static Bitmap DecodeImage(PsdFile psdFile)
         {
-            var bitmap = new Bitmap(psdFile.Columns, psdFile.Rows, PixelFormat.Format32bppArgb);
+            var bitmap = new Bitmap(psdFile.Columns, psdFile.Rows);
 
             //Parallel load each row
             Parallel.For(0, psdFile.Rows, y =>
@@ -53,7 +54,7 @@ namespace bzPSD
 
                                                   lock (bitmap)
                                                   {
-                                                      bitmap.SetPixel(x, y, pixelColor);
+                                                      bitmap[x, y] = pixelColor;
                                                   }
                                               }
                                           });
@@ -65,7 +66,7 @@ namespace bzPSD
         {
             if (layer.Rect.Width == 0 || layer.Rect.Height == 0) return null;
 
-            var bitmap = new Bitmap(layer.Rect.Width, layer.Rect.Height, PixelFormat.Format32bppArgb);
+            var bitmap = new Bitmap(layer.Rect.Width, layer.Rect.Height);
 
             Parallel.For(0, layer.Rect.Height, y =>
             {
@@ -80,15 +81,15 @@ namespace bzPSD
                     if (layer.SortedChannels.ContainsKey(-2))
                     {
                         int maskAlpha = GetColor(layer.MaskData, x, y);
-                        int oldAlpha = pixelColor.A;
+                        int oldAlpha = (int)((Vector4)pixelColor).W;
 
                         int newAlpha = oldAlpha * maskAlpha / 255;
-                        pixelColor = Color.FromArgb(newAlpha, pixelColor);
+                        pixelColor = pixelColor.WithAlpha(newAlpha);
                     }
 
                     lock (bitmap)
                     {
-                        bitmap.SetPixel(x, y, pixelColor);
+                        bitmap[x, y] = pixelColor;
                     }
                 }
             });
@@ -102,7 +103,7 @@ namespace bzPSD
 
             if (mask.Rect.Width == 0 || mask.Rect.Height == 0) return null;
 
-            Bitmap bitmap = new Bitmap(mask.Rect.Width, mask.Rect.Height, PixelFormat.Format32bppArgb);
+            Bitmap bitmap = new Bitmap(mask.Rect.Width, mask.Rect.Height);
 
             Parallel.For(0, layer.Rect.Height, y =>
             {
@@ -116,7 +117,7 @@ namespace bzPSD
 
                     lock (bitmap)
                     {
-                        bitmap.SetPixel(x, y, pixelColor);
+                        bitmap[x, y] = pixelColor;
                     }
                 }
             });
@@ -141,7 +142,7 @@ namespace bzPSD
             switch (psdFile.ColorMode)
             {
                 case ColorMode.RGB:
-                    c = Color.FromArgb(alpha, red, green, blue);
+                    c = Color.FromRgba(red, green, blue, alpha);
                     break;
                 case ColorMode.CMYK:
                     c = CMYKToRGB(red, green, blue, alpha);
@@ -151,7 +152,7 @@ namespace bzPSD
                     break;
                 case ColorMode.Grayscale:
                 case ColorMode.Duotone:
-                    c = Color.FromArgb(red, red, red);
+                    c = Color.FromRgb(red, red, red);
                     break;
                 case ColorMode.Indexed:
                     int index = red;
@@ -197,7 +198,7 @@ namespace bzPSD
                     break;
             }
 
-            if (layer.SortedChannels.ContainsKey(-1)) c = Color.FromArgb(layer.SortedChannels[-1].ImageData[pos], c);
+            if (layer.SortedChannels.ContainsKey(-1)) c = c.WithAlpha(layer.SortedChannels[-1].ImageData[pos]);
 
             return c;
         }

--- a/bzPSD/Thumbnail.cs
+++ b/bzPSD/Thumbnail.cs
@@ -27,9 +27,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
 
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
+using SixLabors.ImageSharp.Processing;
+using Bitmap = SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgb24>;
 
 namespace bzPSD
 {
@@ -61,7 +61,7 @@ namespace bzPSD
 
                     using (MemoryStream strm = new MemoryStream(imgData))
                     {
-                        Image = (Bitmap)System.Drawing.Image.FromStream(strm).Clone();
+                        Image = (Bitmap)SixLabors.ImageSharp.Image.Load(strm).Clone(d => {});
                     }
 
                     if (ID == 1033)
@@ -79,7 +79,7 @@ namespace bzPSD
                 }
                 else
                 {
-                    Image = new Bitmap(width, height, PixelFormat.Format24bppRgb);
+                    Image = new Bitmap(width, height);
                 }
             }
         }

--- a/bzPSD/bzPSD.csproj
+++ b/bzPSD/bzPSD.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi, 

I saw that System.Drawing was in version 5.0 instead of 6 or 7 (which are Windows-only).
So, I thought, maybe you'd like an update to a real cross platform library.